### PR TITLE
Hotfix for datacenters.get region value

### DIFF
--- a/lib/fog/profitbricks/models/compute/datacenter.rb
+++ b/lib/fog/profitbricks/models/compute/datacenter.rb
@@ -10,7 +10,7 @@ module Fog
         attribute :version,    :aliases => "dataCenterVersion"
         attribute :state,      :aliases => "provisioningState"
         attribute :request_id, :aliases => "requestId"
-        attribute :region
+        attribute :region,     :aliases => "location"
 
         attr_accessor :options
 


### PR DESCRIPTION
Corrected the datacenters.get response that was not properly returning the region value due to a missing alias.